### PR TITLE
feat: Downlevel casing-related type aliases

### DIFF
--- a/baselines/reference/ts3.4/test.d.ts
+++ b/baselines/reference/ts3.4/test.d.ts
@@ -71,3 +71,7 @@ export declare const foo: {
 export type IR = IteratorResult<number>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts3.5/test.d.ts
+++ b/baselines/reference/ts3.5/test.d.ts
@@ -71,3 +71,7 @@ export declare const foo: {
 export type IR = IteratorResult<number>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts3.6/test.d.ts
+++ b/baselines/reference/ts3.6/test.d.ts
@@ -73,3 +73,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts3.7/test.d.ts
+++ b/baselines/reference/ts3.7/test.d.ts
@@ -73,3 +73,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts3.8/test.d.ts
+++ b/baselines/reference/ts3.8/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts3.9/test.d.ts
+++ b/baselines/reference/ts3.9/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts4.0/test.d.ts
+++ b/baselines/reference/ts4.0/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = string;
+export type TLowercase = string;
+export type TUppercase = string;
+export type TCapitalize = string;
+export type TUncapitalize = string;

--- a/baselines/reference/ts4.1/test.d.ts
+++ b/baselines/reference/ts4.1/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/baselines/reference/ts4.2/test.d.ts
+++ b/baselines/reference/ts4.2/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/baselines/reference/ts4.3/test.d.ts
+++ b/baselines/reference/ts4.3/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/baselines/reference/ts4.4/test.d.ts
+++ b/baselines/reference/ts4.4/test.d.ts
@@ -74,3 +74,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/baselines/reference/ts4.5/test.d.ts
+++ b/baselines/reference/ts4.5/test.d.ts
@@ -71,3 +71,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/baselines/reference/ts4.6/test.d.ts
+++ b/baselines/reference/ts4.6/test.d.ts
@@ -71,3 +71,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/baselines/reference/ts4.7/test.d.ts
+++ b/baselines/reference/ts4.7/test.d.ts
@@ -71,3 +71,7 @@ export declare const foo: {
 export type IR = IteratorResult<number, string>;
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;

--- a/index.js
+++ b/index.js
@@ -83,10 +83,17 @@ function doTransform(checker, targetVersion, k) {
       }
     }
 
-    if (semver.lt(targetVersion, "4.1.0") && n.kind === ts.SyntaxKind.TemplateLiteralType) {
-      // TemplateLiteralType added in 4.2
+    if (
+      semver.lt(targetVersion, "4.1.0") &&
+      (n.kind === ts.SyntaxKind.TemplateLiteralType ||
+        isTypeReference(n, "Uppercase") ||
+        isTypeReference(n, "Lowercase") ||
+        isTypeReference(n, "Capitalize") ||
+        isTypeReference(n, "Uncapitalize"))
+    ) {
+      // TemplateLiteralType and the casing type alises added in 4.2
       // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#template-literal-types
-      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
     }
 
     if (semver.lt(targetVersion, "3.6.0") && ts.isGetAccessor(n)) {

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -78,3 +78,7 @@ export type IR = IteratorResult<number, string>;
 
 /** Template Literal - supported since 4.1 < should be StringKeyword */
 export type TTemplateLiteral = `${string}abc${string}`;
+export type TLowercase = Lowercase<'HELLO'>;
+export type TUppercase = Uppercase<'hello'>;
+export type TCapitalize = Capitalize<'hello'>;
+export type TUncapitalize = Uncapitalize<'Hello'>;


### PR DESCRIPTION
Downlevels the following casing-related type aliases to string:

* Uppercase
* Lowercase
* Capitalize
* Uncapitalize
